### PR TITLE
Fix Glue table icons

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,5 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 node_modules
+!node_modules/@vscode/codicons/dist/codicon.css
+!node_modules/@vscode/codicons/dist/codicon.ttf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emr-tools",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "emr-tools",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.130.0",
         "@aws-sdk/client-emr": "3.30.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Amazon EMR Toolkit",
   "publisher": "AmazonEMR",
   "description": "The extension for developers building Spark applications to run in EMR clusters.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "preview": true,
   "icon": "resources/emr-icon.png",
   "repository": {


### PR DESCRIPTION
*Issue #, if available:* #7

*Description of changes:*
- Excludes `@vscode/codicons` from `.vscodeignore` so they're included when packaging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
