### PR TITLE
Add an option for log bucket - fixes #20

### DIFF
--- a/src/clients/emrServerlessClient.ts
+++ b/src/clients/emrServerlessClient.ts
@@ -84,7 +84,7 @@ export class DefaultEMRServerlessClient {
         return jobRuns;
       }
   
-    public async startJobRun(applicationId: string, executionRoleARN: string, entryPoint: string): Promise<JobRun> {
+    public async startJobRun(applicationId: string, executionRoleARN: string, entryPoint: string, logPrefix: string): Promise<JobRun> {
       this.globals.outputChannel.appendLine(
         `EMR Serverless: Starting job run (${applicationId}).`
       );
@@ -99,6 +99,14 @@ export class DefaultEMRServerlessClient {
           sparkSubmit: {entryPoint: entryPoint}
         }
       };
+
+      if (logPrefix) {
+        jobRunParams.configurationOverrides = {
+          monitoringConfiguration: {
+            s3MonitoringConfiguration: {logUri: logPrefix}
+          }
+        };
+      }
 
       try {
         const result = await emr.send(


### PR DESCRIPTION
Adds a new option when using the "Run job" command to choose a bucket location for logs:
- Allows an empty value (disables s3 logs)
- Pre-fills with `s3://<previously-input-code-bucket>/logs`